### PR TITLE
Switch Defis page to Windmill

### DIFF
--- a/components.json
+++ b/components.json
@@ -13,7 +13,6 @@
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
-    "ui": "@/components/ui",
     "lib": "@/lib",
     "hooks": "@/hooks"
   },

--- a/src/pages/Defis.jsx
+++ b/src/pages/Defis.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchDefis, createDefi, updateDefi, deleteDefi } from '../services/defiService';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Button, Input, Modal, ModalHeader, ModalBody, ModalFooter } from '@windmill/react-ui';
 import { Pencil, Trash2 } from 'lucide-react';
 
 const Defis = () => {
@@ -140,12 +138,12 @@ const Defis = () => {
 
       {/* MODAL */}
       {isFormOpen && (
-        <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
-          <DialogContent className="sm:max-w-lg">
+        <Modal isOpen={isFormOpen} onClose={() => setIsFormOpen(false)}>
+          <ModalHeader>
+            {selectedDefi ? 'Modifier le défi' : 'Créer un défi'}
+          </ModalHeader>
+          <ModalBody>
             <div className="space-y-4">
-              <h3 className="text-lg font-bold">
-                {selectedDefi ? 'Modifier le défi' : 'Créer un défi'}
-              </h3>
               <Input
                 placeholder="Titre"
                 value={formData.title}
@@ -167,17 +165,19 @@ const Defis = () => {
                 value={formData.endDate}
                 onChange={(e) => setFormData({ ...formData, endDate: e.target.value })}
               />
-              <div className="flex justify-end gap-2 pt-4">
-                <Button variant="secondary" onClick={() => setIsFormOpen(false)}>
-                  Annuler
-                </Button>
-                <Button onClick={handleSubmit}>
-                  {selectedDefi ? 'Modifier' : 'Créer'}
-                </Button>
-              </div>
             </div>
-          </DialogContent>
-        </Dialog>
+          </ModalBody>
+          <ModalFooter>
+            <div className="flex justify-end gap-2 w-full">
+              <Button layout="outline" onClick={() => setIsFormOpen(false)}>
+                Annuler
+              </Button>
+              <Button onClick={handleSubmit}>
+                {selectedDefi ? 'Modifier' : 'Créer'}
+              </Button>
+            </div>
+          </ModalFooter>
+        </Modal>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- migrate `Defis` page dialog to Windmill modal
- cleanup stale alias from `components.json`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c3bb03564832f8eb4591cecb31b4a