### PR TITLE
Add Windmill plugin in Tailwind setup

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,13 @@
 /** @type {import('tailwindcss').Config} */
+import windmill from '@windmill/react-ui';
+
 export default {
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}"
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [windmill],
 };


### PR DESCRIPTION
## Summary
- add the Windmill plugin to `tailwind.config.js`

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_684c3bb1c9d8832fa5aa44d3a34ef3a1