### PR TITLE
Fix dark mode and createDefi logic

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -21,6 +21,7 @@ const useDarkMode = () => {
 };
 
 const Header = ({ toggleSidebar }) => {
+  const [isDark, setIsDark] = useDarkMode();
 
   return (
     <header className="flex items-center justify-between h-16 px-4 bg-white dark:bg-gray-800 border-b border-border">      <div className="flex items-center gap-4">

--- a/src/services/defiService.js
+++ b/src/services/defiService.js
@@ -5,15 +5,21 @@ const API = 'http://localhost:8080/defis';
 export const fetchDefis = () => axios.get(`${API}/all`);
 
 // ✅ Créer un défi via @RequestParam
-export const createDefi = (data) =>
-  axios.post(`${API}/create`, null, {
+export const createDefi = (data) => {
+  const rawStart = data.start_date || data.startDate || '';
+  const rawEnd = data.end_date || data.endDate || '';
+  const startDate = rawStart.includes('T') ? rawStart : `${rawStart}T00:00:00`;
+  const endDate = rawEnd.includes('T') ? rawEnd : `${rawEnd}T00:00:00`;
+
+  return axios.post(`${API}/create`, null, {
     params: {
       title: data.title,
       goal: data.goal,
-      startDate: data.start_date + 'T00:00:00',
-      endDate: data.end_date + 'T00:00:00',
-    }
+      startDate,
+      endDate,
+    },
   });
+};
 
 
 // ✅ Modifier un défi via @RequestBody


### PR DESCRIPTION
## Summary
- fix undefined variable in header component by using useDarkMode
- handle both camelCase and snake_case dates when creating a defi

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684fdacde748832f8d3a7d3baf6b1bb3